### PR TITLE
Correct executable name

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -76,7 +76,7 @@
                   #!${pkgs.bash}/bin/bash
                   mkdir -p /var/lib/simple-vms/${name}
                   cd /var/lib/simple-vms/${name}
-                  exec ${cfg.vm.out}/bin/run-nixos-vm;
+                  exec ${cfg.vm.out}/bin/run-${name}-vm;
                 '';
                 serviceConfig.ExecStopPost = cleanupScript name cfg.persistState;
               };


### PR DESCRIPTION
`config.system.build.vm` now produces an executable whose name includes the VM's hostname: https://github.com/NixOS/nixpkgs/blob/e388728ddf131e4442906f90fd365b11fe999aac/nixos/modules/virtualisation/qemu-vm.nix#L1098